### PR TITLE
Removed product steering meetings

### DIFF
--- a/src/pages/contact.en.md
+++ b/src/pages/contact.en.md
@@ -8,30 +8,30 @@ Do you want to join the community and use OpenZaak?
 
 ### Representatives of the OpenZaak core group
 
-Niels Lindeboom  
-Director Municipal Collaboration  
-Dimpact  
+Niels Lindeboom
+Director Municipal Collaboration
+Dimpact
 [niels.lindeboom@dimpact.nl](mailto:niels.lindeboom@dimpact.nl)
 
 ### Representatives from participating municipalities
-Lazo Bozarov  
-Senior Supply Manager Digital Service  
-Municipality of Utrecht  
+Lazo Bozarov
+Senior Supply Manager Digital Service
+Municipality of Utrecht
 [l.bozarov@utrecht.nl](mailto:l.bozarov@utrecht.nl)
 
 ### Representatives of OpenZaak vendors
-Joeri Bekker  
-Founder Maykin Media BV  
+Joeri Bekker
+Founder Maykin Media BV
 [joeri.bekker@maykinmedia.nl](mailto:joeri.bekker@maykinmedia.nl)
 
-Tahir Malik  
-Technical Director  
-Contezza  
+Tahir Malik
+Technical Director
+Contezza
 [tahir@contezza.nl](mailto:tahir@contezza.nl)
 
 ### Representative of VNG Realisatie (Dutch Association of Municipalities)
-Hugo ter Doest  
-Product owner APIs for business-oriented work, VNG Realisatie  
+Hugo ter Doest
+Product owner APIs for business-oriented work, VNG Realisatie
 [hugo.terdoest@dimpact.nl](mailto:hugo.terdoest@dimpact.nl)
 
 ## Get in touch with The OpenZaak Community
@@ -41,7 +41,3 @@ Would you like to discuss and participate in decisions about the further develop
 ### Monthly Technical Steering call
 
 Every month contributing developer members of our community conduct a technical steering meeting to discuss technical issues or new technical developments. You are welcome to join this meeting by sending a request to openzaak-discuss@lists.publiccode.net. Make sure you first [join the OpenZaak mailinglist](https://lists.publiccode.net/mailman/postorius/lists/openzaak-discuss.lists.publiccode.net/) prior to sending a message.
-
-### Monthly Product Steering call
-
-Every month contributing members of our community conduct a product steering meeting to discuss new features or user issues.  You are welcome to join this meeting by sending a request to openzaak-discuss@lists.publiccode.net. Make sure you first [join the OpenZaak mailinglist](https://lists.publiccode.net/mailman/postorius/lists/openzaak-discuss.lists.publiccode.net/) prior to sending a message.

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -46,8 +46,3 @@ Wil je discussiëren en mee beslissen over de verdere ontwikkeling van OpenZaak?
 ### Maandelijkse Technical Steering call
 
 Elke maand houden ontwikkelaars van onze community een technische stuurbijeenkomst om technische problemen of nieuwe technische ontwikkelingen te bespreken. Je bent van harte welkom om deze bijeenkomst bij te wonen door een verzoek te sturen naar openzaak-discuss@lists.publiccode.net. Zorg ervoor dat je eerst [lid wordt van de OpenZaak mailinglist] (https://lists.publiccode.net/mailman/postorius/lists/openzaak-discuss.lists.publiccode.net/) voordat je een bericht verstuurt.
-
-
-### Maandelijkse Product Steering call
-
-Elke maand houden product owners van onze community een productstuurvergadering om nieuwe functies of gebruikersproblemen te bespreken. U bent van harte welkom om deze bijeenkomst bij te wonen door een verzoek te sturen naar openzaak-discuss@lists.publiccode.net. Zorg ervoor dat je eerst [lid wordt van de OpenZaak mailinglist] (https://lists.publiccode.net/mailman/postorius/lists/openzaak-discuss.lists.publiccode.net/


### PR DESCRIPTION
It is replaced by the kern groep. 