### PR TITLE
Update description of OpenZaak API backend

### DIFF
--- a/src/pages/using-openzaak.md
+++ b/src/pages/using-openzaak.md
@@ -14,7 +14,7 @@ Wilt u meer weten over hoe u OpenZaak in uw gemeente kunt gaan gebruiken?
 
 ## Voor ontwikkelaars
 
-OpenZaak is een open source API provisioning backend.
+OpenZaak is een open source ZGW API backend.
 
 OpenZaak implementeert de landelijke API-standaarden voor zaakgericht werken ([ZGW API's](https://github.com/VNG-Realisatie/gemma-zaken)) ontwikkeld in opdracht van de Nederlandse Vereniging van Gemeenten ([VNG Realisatie](https://www.vngrealisatie.nl)).
 


### PR DESCRIPTION
De beschrijving is verwarrend, met 'provisioning backend' zou je of kunnen denken aan een API gateway of aan het provisionen van gebruikers.

Beide interpretaties kloppen niet, en deze term komt ook alleen voor in de documentatie wanneer het gaat om het provisionen van beheerders/superusers: https://open-zaak.readthedocs.io/en/latest/index.html 

Dus ik wil voorstellen om het niet langer over 'provisioning backend' te hebben